### PR TITLE
Add bananas collectible and UI counter

### DIFF
--- a/Banana.tscn
+++ b/Banana.tscn
@@ -1,6 +1,7 @@
 [gd_scene load_steps=3 format=3 uid="uid://c7fy4ba4s1ti8"]
 
 [ext_resource type="Texture2D" uid="uid://csnhnjduld8wu" path="res://img/itemy/banana.png" id="1_ej4t0"]
+[ext_resource type="Script" path="res://banana.gd" id="1_ban"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_ej4t0"]
 radius = 32.0
@@ -8,6 +9,7 @@ height = 64.0
 
 [node name="Area2D" type="Area2D"]
 position = Vector2(658, 573)
+script = ExtResource("1_ban")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 position = Vector2(-1, 1)

--- a/banana.gd
+++ b/banana.gd
@@ -1,0 +1,9 @@
+extends Area2D
+
+func _ready():
+        body_entered.connect(_on_body_entered)
+
+func _on_body_entered(body: Node):
+        if body.has_method("collect_banana"):
+                body.collect_banana()
+        queue_free()

--- a/main.tscn
+++ b/main.tscn
@@ -33,6 +33,7 @@
 [ext_resource type="PackedScene" uid="uid://dtl565i0i5mbl" path="res://obstacle_ch.tscn" id="27_htxhm"]
 [ext_resource type="PackedScene" uid="uid://dung0xbr6lxnp" path="res://obstacle_stul.tscn" id="28_jq2sk"]
 [ext_resource type="AudioStream" uid="uid://drqvifxds25bj" path="res://sounds/railway.ogg" id="31_seu75"]
+[ext_resource type="PackedScene" path="res://Banana.tscn" id="32_ban"]
 
 [sub_resource type="LabelSettings" id="LabelSettings_d13ii"]
 font = ExtResource("1_ryguw")
@@ -220,6 +221,13 @@ label_settings = SubResource("LabelSettings_d13ii")
 horizontal_alignment = 1
 language = "cs"
 
+[node name="BananaLabel" type="Label" parent="UI"]
+offset_right = 1279.0
+offset_bottom = 60.0
+text = "0"
+label_settings = SubResource("LabelSettings_d13ii")
+horizontal_alignment = 1
+
 [node name="Background" type="Node2D" parent="."]
 script = ExtResource("3_h2yge")
 
@@ -263,6 +271,7 @@ stream = ExtResource("24_4k2k6")
 script = ExtResource("20_getpj")
 wagon_scene = ExtResource("21_getpj")
 obstacle_scenes = Array[PackedScene]([ExtResource("25_kq58d"), ExtResource("26_seu75"), ExtResource("27_htxhm"), ExtResource("28_jq2sk")])
+banana_scene = ExtResource("32_ban")
 
 [node name="GameOver" type="CanvasLayer" parent="."]
 offset = Vector2(-200, -100)

--- a/player.gd
+++ b/player.gd
@@ -126,6 +126,9 @@ func die():
 	gameover_node.show_gameover(distance_traveled, wagons_skipped)
 
 func register_wagon(id: int):
-	if id != last_wagon_id:
-		wagons_skipped += 1
-		last_wagon_id = id
+        if id != last_wagon_id:
+                wagons_skipped += 1
+                last_wagon_id = id
+
+func collect_banana(amount: int = 1):
+        ui_node.add_banana(amount)

--- a/train.gd
+++ b/train.gd
@@ -7,9 +7,12 @@ extends Node2D
 @export var wagon_width := 970.0
 @export var wagon_y := 200  # výška, kam umístit vagóny
 @export var obstacle_scenes: Array[PackedScene] = []
+@export var banana_scene: PackedScene
+@export var banana_chance := 0.3
 
 var is_moving := false
 var obstacle_chance := 0.2  # Začíná na 20%
+var current_distance := 0.0
 
 func _ready():
 	_generate_initial_wagons()
@@ -28,18 +31,28 @@ func _generate_initial_wagons():
 		_spawn_wagon_at(i * (wagon_width + wagon_spacing))
 
 func _spawn_wagon_at(x_pos: float):
-	if wagon_scene:
-		var new_wagon = wagon_scene.instantiate()
-		new_wagon.position = Vector2(x_pos, wagon_y)
-		add_child(new_wagon)
-		
-		# Zkus generovat překážku
-		if obstacle_scenes.size() > 0 and randf() < obstacle_chance:
-			var spawn_point := new_wagon.get_node_or_null("ObstacleSpawn")
-			if spawn_point:
-				var obstacle_scene := obstacle_scenes[randi() % obstacle_scenes.size()]
-				var obstacle = obstacle_scene.instantiate()
-				spawn_point.add_child(obstacle)
+        if wagon_scene:
+                var new_wagon = wagon_scene.instantiate()
+                new_wagon.position = Vector2(x_pos, wagon_y)
+                add_child(new_wagon)
+
+                # Zkus generovat překážku
+                if obstacle_scenes.size() > 0 and randf() < obstacle_chance:
+                        var spawn_point := new_wagon.get_node_or_null("ObstacleSpawn")
+                        if spawn_point:
+                                var obstacle_scene := obstacle_scenes[randi() % obstacle_scenes.size()]
+                                var obstacle = obstacle_scene.instantiate()
+                                spawn_point.add_child(obstacle)
+
+                # Zkus generovat banán
+                if banana_scene and randf() < banana_chance:
+                        var spawn_banana := new_wagon.get_node_or_null("ObstacleSpawn")
+                        if spawn_banana:
+                                var stack := 1 + int(current_distance / 500.0)
+                                for i in range(stack):
+                                        var banana = banana_scene.instantiate()
+                                        banana.position.y -= i * 20
+                                        spawn_banana.add_child(banana)
 
 func _check_for_generation():
 	var rightmost_x := -INF
@@ -52,5 +65,6 @@ func _check_for_generation():
 		_spawn_wagon_at(rightmost_x + wagon_width + wagon_spacing)
 
 func increase_difficulty(distance: float):
-	# Zvýšíme pravděpodobnost, ale max na 90 %
-	obstacle_chance = clamp(0.2 + distance / 3000.0, 0.2, 0.9)
+        # Zvýšíme pravděpodobnost, ale max na 90 %
+        obstacle_chance = clamp(0.2 + distance / 3000.0, 0.2, 0.9)
+        current_distance = distance

--- a/ui.gd
+++ b/ui.gd
@@ -1,15 +1,24 @@
 extends CanvasLayer
 
 var distance := 0.0
+var bananas := 0
 
 @onready var score_label: Label = $ScoreLabel
+@onready var banana_label: Label = $BananaLabel
 
 func _process(delta):
-	# Tady se distance pouze zobrazuje
-	score_label.text = "%.2fm" % distance
+        # Tady se distance pouze zobrazuje
+        score_label.text = "%.2fm" % distance
+        banana_label.text = "%d" % bananas
 
 func add_distance(amount: float):
-	distance += amount
+        distance += amount
+
+func add_banana(amount: int = 1):
+        bananas += amount
+
+func reset_bananas():
+        bananas = 0
 
 func reset_distance():
 	distance = 0.0


### PR DESCRIPTION
## Summary
- add script for banana Area2D and connect to player
- display banana count in UI
- allow Player to collect bananas
- spawn bananas on wagons in Train logic
- wire Banana scene and label in `main.tscn`

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859af35f0bc83229aa427bb7bf206fb