### PR TITLE
Fix obstacle collision and show achievements

### DIFF
--- a/game_over.gd
+++ b/game_over.gd
@@ -7,6 +7,23 @@ extends CanvasLayer
 @onready var scoreboard: VBoxContainer = $ColorRect/CenterContainer/VBoxContainer/VBoxContainer
 @onready var restart_button: Button = $ColorRect/CenterContainer/VBoxContainer/restart
 
+# Container for dynamically created achievement buttons
+var achievements_container: VBoxContainer
+
+# Definitions for achievements
+const ACHIEVEMENTS := [
+    {"label": "100m", "type": "distance", "value": 100.0},
+    {"label": "250m", "type": "distance", "value": 250.0},
+    {"label": "500m", "type": "distance", "value": 500.0},
+    {"label": "750m", "type": "distance", "value": 750.0},
+    {"label": "1000m", "type": "distance", "value": 1000.0},
+    {"label": "10 bananas", "type": "bananas", "value": 10},
+    {"label": "50 bananas", "type": "bananas", "value": 50},
+    {"label": "100 bananas", "type": "bananas", "value": 100},
+]
+
+var achievement_buttons: Array = []
+
 @export var transition_player_path: NodePath
 @onready var transition_anim := get_node(transition_player_path).get_node("TransitionPlayer")
 
@@ -15,16 +32,27 @@ var current_distance := 0.0
 var current_skipped := 0
 
 func _ready():
-	visible = false
-	save_button.pressed.connect(_on_save_pressed)
-	restart_button.pressed.connect(_on_restart_pressed)
+        visible = false
+        save_button.pressed.connect(_on_save_pressed)
+        restart_button.pressed.connect(_on_restart_pressed)
+
+        # Build achievements UI
+        achievements_container = VBoxContainer.new()
+        $ColorRect/CenterContainer/VBoxContainer.add_child(achievements_container)
+        for ach in ACHIEVEMENTS:
+                var btn := Button.new()
+                btn.text = ach["label"]
+                btn.disabled = true
+                achievements_container.add_child(btn)
+                achievement_buttons.append(btn)
 
 func show_gameover(distance: float, wagons: int):
-	current_distance = distance
-	current_skipped = wagons
-	label_metry.text = "Uletěl jsi %.2f m\nPřeskočil jsi %d vagónů" % [distance, wagons]
-	visible = true
-	line_edit.grab_focus()
+        current_distance = distance
+        current_skipped = wagons
+        label_metry.text = "Uletěl jsi %.2f m\nPřeskočil jsi %d vagónů" % [distance, wagons]
+        _update_achievements()
+        visible = true
+        line_edit.grab_focus()
 
 func _on_save_pressed():
 	var playername = line_edit.text.strip_edges()
@@ -38,9 +66,21 @@ func _on_save_pressed():
 	save_button.disabled = true
 
 func update_scoreboard():
-	scoreboard.get_node("Label4").text = "1. %s" % Hra.get_score_string(0)
-	scoreboard.get_node("Label5").text = "2. %s" % Hra.get_score_string(1)
-	scoreboard.get_node("Label6").text = "3. %s" % Hra.get_score_string(2)
+        scoreboard.get_node("Label4").text = "1. %s" % Hra.get_score_string(0)
+        scoreboard.get_node("Label5").text = "2. %s" % Hra.get_score_string(1)
+        scoreboard.get_node("Label6").text = "3. %s" % Hra.get_score_string(2)
+
+func _update_achievements():
+        for i in ACHIEVEMENTS.size():
+                var ach = ACHIEVEMENTS[i]
+                var unlocked := false
+                if ach.type == "distance":
+                        unlocked = current_distance >= ach.value
+                else:
+                        unlocked = Hra.banana_total >= ach.value
+
+                var btn: Button = achievement_buttons[i]
+                btn.text = (unlocked ? "✓ " : "") + ach.label
 
 func _on_restart_pressed():
 	transition_anim.play("blesk")

--- a/main.tscn
+++ b/main.tscn
@@ -237,6 +237,15 @@ offset_bottom = 112.0
 texture = ExtResource("33_icon")
 stretch_mode = 3
 
+[node name="AchievementPopup" type="Button" parent="UI"]
+offset_left = 490.0
+offset_top = 320.0
+offset_right = 790.0
+offset_bottom = 360.0
+text = "ACHIEVEMENT"
+disabled = true
+visible = false
+
 [node name="Background" type="Node2D" parent="."]
 script = ExtResource("3_h2yge")
 

--- a/obstacle.gd
+++ b/obstacle.gd
@@ -1,0 +1,8 @@
+extends Area2D
+
+func _ready():
+    body_entered.connect(_on_body_entered)
+
+func _on_body_entered(body: Node) -> void:
+    if body.has_method("die"):
+        body.die()

--- a/obstacle_ch.tscn
+++ b/obstacle_ch.tscn
@@ -1,11 +1,13 @@
 [gd_scene load_steps=3 format=3 uid="uid://dtl565i0i5mbl"]
 
 [ext_resource type="Texture2D" uid="uid://d2lpcbdj6cfwn" path="res://img/prekazky/crackhead.png" id="1_je6wx"]
+[ext_resource type="Script" path="res://obstacle.gd" id="1_scrpt"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_87rtl"]
 size = Vector2(61, 64)
 
 [node name="ObstacleCH" type="Area2D"]
+script = ExtResource("1_scrpt")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 position = Vector2(528, 651)

--- a/obstacle_pec.tscn
+++ b/obstacle_pec.tscn
@@ -1,11 +1,13 @@
 [gd_scene load_steps=3 format=3 uid="uid://deunaoy5wmbn8"]
 
 [ext_resource type="Texture2D" uid="uid://bn7w3ut22rl0s" path="res://img/prekazky/pec.png" id="1_bvcmp"]
+[ext_resource type="Script" path="res://obstacle.gd" id="1_scrpt"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_87rtl"]
 size = Vector2(54, 71)
 
 [node name="ObstaclePec" type="Area2D"]
+script = ExtResource("1_scrpt")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 position = Vector2(530, 641)

--- a/obstacle_stul.tscn
+++ b/obstacle_stul.tscn
@@ -1,11 +1,13 @@
 [gd_scene load_steps=3 format=3 uid="uid://dung0xbr6lxnp"]
 
 [ext_resource type="Texture2D" uid="uid://dke6kf54aejf8" path="res://img/prekazky/stul.png" id="1_igu1d"]
+[ext_resource type="Script" path="res://obstacle.gd" id="1_scrpt"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_87rtl"]
 size = Vector2(80, 62.5)
 
 [node name="ObstacleStul" type="Area2D"]
+script = ExtResource("1_scrpt")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 position = Vector2(493, 655)

--- a/obstacle_tv.tscn
+++ b/obstacle_tv.tscn
@@ -1,11 +1,13 @@
 [gd_scene load_steps=3 format=3 uid="uid://c71kal3lrowvt"]
 
 [ext_resource type="Texture2D" uid="uid://cxgp24oa60saj" path="res://img/prekazky/televize.png" id="1_30d0d"]
+[ext_resource type="Script" path="res://obstacle.gd" id="1_scrpt"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_vap5s"]
 size = Vector2(215.575, 187.16)
 
 [node name="ObstacleTV" type="Area2D"]
+script = ExtResource("1_scrpt")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 position = Vector2(522, 641)

--- a/ui.gd
+++ b/ui.gd
@@ -3,19 +3,37 @@ extends CanvasLayer
 var distance := 0.0
 var bananas := 0
 
+# Achievement definitions
+const ACHIEVEMENTS := [
+    {"label": "100m", "type": "distance", "value": 100.0},
+    {"label": "250m", "type": "distance", "value": 250.0},
+    {"label": "500m", "type": "distance", "value": 500.0},
+    {"label": "750m", "type": "distance", "value": 750.0},
+    {"label": "1000m", "type": "distance", "value": 1000.0},
+    {"label": "10 bananas", "type": "bananas", "value": 10},
+    {"label": "50 bananas", "type": "bananas", "value": 50},
+    {"label": "100 bananas", "type": "bananas", "value": 100},
+]
+
+var unlocked := []
+
 @onready var score_label: Label = $ScoreLabel
 @onready var banana_label: Label = $BananaLabel
+@onready var achievement_popup: Button = $AchievementPopup
 
 func _ready():
         bananas = Hra.banana_total
+        unlocked.resize(ACHIEVEMENTS.size())
+        achievement_popup.hide()
 
 func _process(delta):
-		# Tady se distance pouze zobrazuje
-		score_label.text = "%.2fm" % distance
-		banana_label.text = "%d" % bananas
+                # Tady se distance pouze zobrazuje
+                score_label.text = "%.2fm" % distance
+                banana_label.text = "%d" % bananas
+                _check_achievements()
 
 func add_distance(amount: float):
-		distance += amount
+                distance += amount
 
 func add_banana(amount: int = 1):
                 Hra.add_banana(amount)
@@ -25,4 +43,28 @@ func reset_bananas():
                 bananas = Hra.banana_total
 
 func reset_distance():
-	distance = 0.0
+        distance = 0.0
+
+func _check_achievements():
+        for i in ACHIEVEMENTS.size():
+                if unlocked[i]:
+                        continue
+                var ach = ACHIEVEMENTS[i]
+                var condition := false
+                if ach.type == "distance":
+                        condition = distance >= ach.value
+                else:
+                        condition = bananas >= ach.value
+                if condition:
+                        unlocked[i] = true
+                        _show_achievement(ach.label)
+
+func _show_achievement(text: String):
+        achievement_popup.text = text
+        achievement_popup.show()
+        achievement_popup.modulate.a = 0.0
+        var tw = create_tween()
+        tw.tween_property(achievement_popup, "modulate:a", 1.0, 0.4)
+        tw.tween_interval(1.2)
+        tw.tween_property(achievement_popup, "modulate:a", 0.0, 0.4)
+        tw.finished.connect(achievement_popup.hide)


### PR DESCRIPTION
## Summary
- ensure obstacles kill the player when touched
- add an AchievementPopup button to the UI
- trigger achievement popups as soon as goals are reached

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6859b9c0c52c8322abc677adcfd75b74