### PR TITLE
Adjust banana difficulty and game over layout

### DIFF
--- a/game_over.gd
+++ b/game_over.gd
@@ -37,14 +37,21 @@ func _ready():
 		restart_button.pressed.connect(_on_restart_pressed)
 
 		# Build achievements UI
-		achievements_container = VBoxContainer.new()
-		$ColorRect/CenterContainer/VBoxContainer.add_child(achievements_container)
-		for ach in ACHIEVEMENTS:
-				var btn := Button.new()
-				btn.text = ach["label"]
-				btn.disabled = true
-				achievements_container.add_child(btn)
-				achievement_buttons.append(btn)
+                achievements_container = VBoxContainer.new()
+                $ColorRect.add_child(achievements_container)
+                achievements_container.anchor_left = 0
+                achievements_container.anchor_top = 0.5
+                achievements_container.position = Vector2(40, -100)
+
+                for ach in ACHIEVEMENTS:
+                                var btn := Button.new()
+                                btn.text = ach["label"]
+                                btn.disabled = true
+                                achievements_container.add_child(btn)
+                                achievement_buttons.append(btn)
+
+                # Make the name input wider for easier typing
+                line_edit.custom_minimum_size = Vector2(300, 0)
 
 func show_gameover(distance: float, wagons: int):
 		current_distance = distance

--- a/train.gd
+++ b/train.gd
@@ -49,10 +49,11 @@ func _spawn_wagon_at(x_pos: float):
 						var spawn_banana := new_wagon.get_node_or_null("ObstacleSpawn")
 						if spawn_banana:
 								var stack := 1 + int(current_distance / 500.0)
-								for i in range(stack):
-										var banana = banana_scene.instantiate()
-										banana.position.y -= i * 20
-										spawn_banana.add_child(banana)
+                                                                for i in range(stack):
+                                                                               var banana = banana_scene.instantiate()
+                                                                               # Spawn bananas slightly higher so they are harder to collect
+                                                                               banana.position.y -= 40 + i * 30
+                                                                               spawn_banana.add_child(banana)
 
 func _check_for_generation():
 	var rightmost_x := -INF


### PR DESCRIPTION
## Summary
- make bananas spawn higher by adding extra vertical offset
- move achievements list to left side of the screen
- enlarge name input field on game over screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859ca6d69c88322b2bbe6caa481cab0