### PR TITLE
Fix achievements visibility and persistence

### DIFF
--- a/addons/hra/hra.gd
+++ b/addons/hra/hra.gd
@@ -7,9 +7,15 @@ const SAVE_PATH := "user://scoreboard.save"
 var banana_total := 0
 const BANANA_SAVE_PATH := "user://bananas.save"
 
+# Persistent achievement completion
+var achievements_completed := []
+const ACHIEVEMENTS_SAVE_PATH := "user://achievements.save"
+const ACHIEVEMENTS_COUNT := 8
+
 func _ready():
-		load_scores()
-		load_bananas()
+                load_scores()
+                load_bananas()
+                load_achievements()
 
 func save_score(distance: float, name: String):
 		top_scores.append({ "name": name, "score": distance })
@@ -45,8 +51,27 @@ func save_bananas():
 		file.store_var(banana_total)
 
 func load_bananas():
-		if FileAccess.file_exists(BANANA_SAVE_PATH):
-				var file = FileAccess.open(BANANA_SAVE_PATH, FileAccess.READ)
-				banana_total = file.get_var()
-		else:
-				banana_total = 0
+                if FileAccess.file_exists(BANANA_SAVE_PATH):
+                                var file = FileAccess.open(BANANA_SAVE_PATH, FileAccess.READ)
+                                banana_total = file.get_var()
+                else:
+                                banana_total = 0
+
+# -- Achievement persistence ---------------------------------------------
+func save_achievements():
+                var file = FileAccess.open(ACHIEVEMENTS_SAVE_PATH, FileAccess.WRITE)
+                file.store_var(achievements_completed)
+
+func load_achievements():
+                if FileAccess.file_exists(ACHIEVEMENTS_SAVE_PATH):
+                                var file = FileAccess.open(ACHIEVEMENTS_SAVE_PATH, FileAccess.READ)
+                                achievements_completed = file.get_var()
+                else:
+                                achievements_completed.resize(ACHIEVEMENTS_COUNT)
+                                for i in ACHIEVEMENTS_COUNT:
+                                                achievements_completed[i] = false
+
+func mark_achievement(idx: int):
+                if idx >= 0 and idx < ACHIEVEMENTS_COUNT:
+                                achievements_completed[idx] = true
+                                save_achievements()

--- a/game_over.gd
+++ b/game_over.gd
@@ -39,9 +39,9 @@ func _ready():
 		# Build achievements UI
 		achievements_container = VBoxContainer.new()
 		$ColorRect.add_child(achievements_container)
-		achievements_container.anchor_left = 0
-		achievements_container.anchor_top = 0.5
-		achievements_container.position = Vector2(240, -500)
+                achievements_container.anchor_left = 0
+                achievements_container.anchor_top = 0
+                achievements_container.position = Vector2(20, 100)
 
 		for ach in ACHIEVEMENTS:
 			var btn := Button.new()
@@ -78,13 +78,14 @@ func update_scoreboard():
 		scoreboard.get_node("Label6").text = "3. %s" % Hra.get_score_string(2)
 
 func _update_achievements():
-		for i in ACHIEVEMENTS.size():
-				var ach = ACHIEVEMENTS[i]
-				var unlocked := false
-				if ach.type == "distance":
-						unlocked = current_distance >= ach.value
-				else:
-						unlocked = Hra.banana_total >= ach.value
+                for i in ACHIEVEMENTS.size():
+                                var ach = ACHIEVEMENTS[i]
+                                var unlocked := false
+                                if ach.type == "distance":
+                                                unlocked = current_distance >= ach.value
+                                else:
+                                                unlocked = Hra.banana_total >= ach.value
+                                unlocked = unlocked or (i < Hra.achievements_completed.size() and Hra.achievements_completed[i])
 
 				var btn: Button = achievement_buttons[i]
 				btn.text = ("\u2713 " + ach.label) if unlocked else ach.label

--- a/ui.gd
+++ b/ui.gd
@@ -22,9 +22,14 @@ var unlocked := []
 @onready var achievement_popup: Button = $AchievementPopup
 
 func _ready():
-		bananas = Hra.banana_total
-		unlocked.resize(ACHIEVEMENTS.size())
-		achievement_popup.hide()
+                bananas = Hra.banana_total
+                unlocked = Hra.achievements_completed.duplicate()
+                if unlocked.size() < ACHIEVEMENTS.size():
+                                unlocked.resize(ACHIEVEMENTS.size())
+                                for i in ACHIEVEMENTS.size():
+                                                if i >= Hra.achievements_completed.size():
+                                                                unlocked[i] = false
+                achievement_popup.hide()
 
 func _process(delta):
 				# Tady se distance pouze zobrazuje
@@ -46,18 +51,19 @@ func reset_distance():
 		distance = 0.0
 
 func _check_achievements():
-		for i in ACHIEVEMENTS.size():
-				if unlocked[i]:
-						continue
-				var ach = ACHIEVEMENTS[i]
-				var condition := false
-				if ach.type == "distance":
-						condition = distance >= ach.value
-				else:
-						condition = bananas >= ach.value
-				if condition:
-						unlocked[i] = true
-						_show_achievement(ach.label)
+                for i in ACHIEVEMENTS.size():
+                                if unlocked[i]:
+                                                continue
+                                var ach = ACHIEVEMENTS[i]
+                                var condition := false
+                                if ach.type == "distance":
+                                                condition = distance >= ach.value
+                                else:
+                                                condition = bananas >= ach.value
+                                if condition:
+                                                unlocked[i] = true
+                                                _show_achievement(ach.label)
+                                                Hra.mark_achievement(i)
 
 func _show_achievement(text: String):
 		achievement_popup.text = text


### PR DESCRIPTION
## Summary
- reposition achievement list on Game Over screen
- persist unlocked achievements across sessions
- load saved achievements in the UI and mark them as unlocked
- mark achievements as completed when earned

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b112c84908322a9791c6acc61b278