### PR TITLE
Fix achievements persistence logic

### DIFF
--- a/addons/hra/hra.gd
+++ b/addons/hra/hra.gd
@@ -7,9 +7,15 @@ const SAVE_PATH := "user://scoreboard.save"
 var banana_total := 0
 const BANANA_SAVE_PATH := "user://bananas.save"
 
+# Persistent achievement completion
+var achievements_completed := []
+const ACHIEVEMENTS_SAVE_PATH := "user://achievements.save"
+const ACHIEVEMENTS_COUNT := 9
+
 func _ready():
-		load_scores()
-		load_bananas()
+                load_scores()
+                load_bananas()
+                load_achievements()
 
 func save_score(distance: float, name: String):
 		top_scores.append({ "name": name, "score": distance })
@@ -45,8 +51,32 @@ func save_bananas():
 		file.store_var(banana_total)
 
 func load_bananas():
-		if FileAccess.file_exists(BANANA_SAVE_PATH):
-				var file = FileAccess.open(BANANA_SAVE_PATH, FileAccess.READ)
-				banana_total = file.get_var()
-		else:
-				banana_total = 0
+                if FileAccess.file_exists(BANANA_SAVE_PATH):
+                                var file = FileAccess.open(BANANA_SAVE_PATH, FileAccess.READ)
+                                banana_total = file.get_var()
+                else:
+                                banana_total = 0
+
+# -- Achievement persistence ---------------------------------------------
+func save_achievements():
+                var file = FileAccess.open(ACHIEVEMENTS_SAVE_PATH, FileAccess.WRITE)
+                file.store_var(achievements_completed)
+
+func load_achievements():
+                if FileAccess.file_exists(ACHIEVEMENTS_SAVE_PATH):
+                                var file = FileAccess.open(ACHIEVEMENTS_SAVE_PATH, FileAccess.READ)
+                                achievements_completed = file.get_var()
+                                if achievements_completed.size() < ACHIEVEMENTS_COUNT:
+                                                var old_size = achievements_completed.size()
+                                                achievements_completed.resize(ACHIEVEMENTS_COUNT)
+                                                for i in range(old_size, ACHIEVEMENTS_COUNT):
+                                                                achievements_completed[i] = false
+                else:
+                                achievements_completed.resize(ACHIEVEMENTS_COUNT)
+                                for i in ACHIEVEMENTS_COUNT:
+                                                achievements_completed[i] = false
+
+func mark_achievement(idx: int):
+                if idx >= 0 and idx < ACHIEVEMENTS_COUNT:
+                                achievements_completed[idx] = true
+                                save_achievements()

--- a/game_over.gd
+++ b/game_over.gd
@@ -39,9 +39,9 @@ func _ready():
 		# Build achievements UI
 		achievements_container = VBoxContainer.new()
 		$ColorRect.add_child(achievements_container)
-		achievements_container.anchor_left = 0
-		achievements_container.anchor_top = 0.5
-		achievements_container.position = Vector2(240, -500)
+                achievements_container.anchor_left = 0
+                achievements_container.anchor_top = 0
+                achievements_container.position = Vector2(20, 100)
 
 		for ach in ACHIEVEMENTS:
 			var btn := Button.new()
@@ -78,16 +78,12 @@ func update_scoreboard():
 		scoreboard.get_node("Label6").text = "3. %s" % Hra.get_score_string(2)
 
 func _update_achievements():
-		for i in ACHIEVEMENTS.size():
-				var ach = ACHIEVEMENTS[i]
-				var unlocked := false
-				if ach.type == "distance":
-						unlocked = current_distance >= ach.value
-				else:
-						unlocked = Hra.banana_total >= ach.value
+                for i in ACHIEVEMENTS.size():
+                                var ach = ACHIEVEMENTS[i]
+                                var unlocked := i < Hra.achievements_completed.size() and Hra.achievements_completed[i]
 
-				var btn: Button = achievement_buttons[i]
-				btn.text = ("\u2713 " + ach.label) if unlocked else ach.label
+                                var btn: Button = achievement_buttons[i]
+                                btn.text = ("\u2713 " + ach.label) if unlocked else ach.label
 
 func _on_restart_pressed():
 	transition_anim.play("blesk")

--- a/player.gd
+++ b/player.gd
@@ -79,12 +79,13 @@ func _physics_process(delta):
 		
 		var t = hold_time / MAX_HOLD_TIME
 		var curved = jump_curve.sample(t)
-		var jump_force = lerp(BASE_JUMP_STRENGTH, MAX_JUMP_STRENGTH, curved)
-		velocity.y = jump_force
+                var jump_force = lerp(BASE_JUMP_STRENGTH, MAX_JUMP_STRENGTH, curved)
+                velocity.y = jump_force
 
-		jump_sound.play()
-		train_node.set_moving(true)
-		start_parallax_transition(background_node.get_current_speed(), parallax_speed_air)
+                jump_sound.play()
+                ui_node.add_jump()
+                train_node.set_moving(true)
+                start_parallax_transition(background_node.get_current_speed(), parallax_speed_air)
 
 	var now_on_floor = is_on_floor()
 	if not was_on_floor and now_on_floor:

--- a/ui.gd
+++ b/ui.gd
@@ -2,17 +2,20 @@ extends CanvasLayer
 
 var distance := 0.0
 var bananas := 0
+var max_bananas := 0
+var jump_count := 0
 
 # Achievement definitions
 const ACHIEVEMENTS := [
-	{"label": "100m", "type": "distance", "value": 100.0},
-	{"label": "250m", "type": "distance", "value": 250.0},
-	{"label": "500m", "type": "distance", "value": 500.0},
-	{"label": "750m", "type": "distance", "value": 750.0},
-	{"label": "1000m", "type": "distance", "value": 1000.0},
-	{"label": "10 bananas", "type": "bananas", "value": 10},
-	{"label": "50 bananas", "type": "bananas", "value": 50},
-	{"label": "100 bananas", "type": "bananas", "value": 100},
+        {"label": "100m", "type": "distance", "value": 100.0},
+        {"label": "250m", "type": "distance", "value": 250.0},
+        {"label": "500m", "type": "distance", "value": 500.0},
+        {"label": "750m", "type": "distance", "value": 750.0},
+        {"label": "1000m", "type": "distance", "value": 1000.0},
+        {"label": "10 bananas", "type": "bananas", "value": 10},
+        {"label": "50 bananas", "type": "bananas", "value": 50},
+        {"label": "100 bananas", "type": "bananas", "value": 100},
+        {"label": "5 jumps", "type": "jumps", "value": 5},
 ]
 
 var unlocked := []
@@ -22,9 +25,16 @@ var unlocked := []
 @onready var achievement_popup: Button = $AchievementPopup
 
 func _ready():
-		bananas = Hra.banana_total
-		unlocked.resize(ACHIEVEMENTS.size())
-		achievement_popup.hide()
+               bananas = Hra.banana_total
+               max_bananas = bananas
+               jump_count = 0
+               unlocked = Hra.achievements_completed.duplicate()
+                if unlocked.size() < ACHIEVEMENTS.size():
+                                unlocked.resize(ACHIEVEMENTS.size())
+                                for i in ACHIEVEMENTS.size():
+                                                if i >= Hra.achievements_completed.size():
+                                                                unlocked[i] = false
+                achievement_popup.hide()
 
 func _process(delta):
 				# Tady se distance pouze zobrazuje
@@ -33,31 +43,43 @@ func _process(delta):
 				_check_achievements()
 
 func add_distance(amount: float):
-				distance += amount
+                               distance += amount
+
+func add_jump():
+                               jump_count += 1
 
 func add_banana(amount: int = 1):
-				Hra.add_banana(amount)
-				bananas = Hra.banana_total
+                               Hra.add_banana(amount)
+                               bananas = Hra.banana_total
+                               if bananas > max_bananas:
+                                               max_bananas = bananas
 
 func reset_bananas():
-				bananas = Hra.banana_total
+                               bananas = Hra.banana_total
+                               max_bananas = bananas
 
 func reset_distance():
-		distance = 0.0
+               distance = 0.0
+               jump_count = 0
 
 func _check_achievements():
-		for i in ACHIEVEMENTS.size():
-				if unlocked[i]:
-						continue
-				var ach = ACHIEVEMENTS[i]
-				var condition := false
-				if ach.type == "distance":
-						condition = distance >= ach.value
-				else:
-						condition = bananas >= ach.value
-				if condition:
-						unlocked[i] = true
-						_show_achievement(ach.label)
+               for i in ACHIEVEMENTS.size():
+                               if unlocked[i]:
+                                               continue
+                               var ach = ACHIEVEMENTS[i]
+                               var condition := false
+                               if ach.type == "distance":
+                                               condition = distance >= ach.value
+                               elif ach.type == "bananas":
+                                               condition = max_bananas >= ach.value
+                               elif ach.type == "jumps":
+                                               condition = jump_count >= ach.value
+                               else:
+                                               condition = false
+                               if condition:
+                                               unlocked[i] = true
+                                               _show_achievement(ach.label)
+                                               Hra.mark_achievement(i)
 
 func _show_achievement(text: String):
 		achievement_popup.text = text


### PR DESCRIPTION
## Summary
- persist achievement completion count with new achievement slots
- expand list to include a jump achievement example
- track jump count and max bananas in `ui.gd`
- show only unlocked achievements on Game Over screen
- notify UI when player jumps

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b112c84908322a9791c6acc61b278