### PR TITLE
Add achievements label and sound effects

### DIFF
--- a/game_over.gd
+++ b/game_over.gd
@@ -32,26 +32,32 @@ var current_distance := 0.0
 var current_skipped := 0
 
 func _ready():
-	visible = false
-	save_button.pressed.connect(_on_save_pressed)
-	restart_button.pressed.connect(_on_restart_pressed)
+        visible = false
+        save_button.pressed.connect(_on_save_pressed)
+        restart_button.pressed.connect(_on_restart_pressed)
 
-	# Build achievements UI
-	achievements_container = VBoxContainer.new()
-	$ColorRect.add_child(achievements_container)
-	achievements_container.anchor_left = 0
-	achievements_container.anchor_top = 0
-	achievements_container.position = Vector2(870, 250)
+        # Build achievements UI
+        achievements_container = VBoxContainer.new()
+        $ColorRect.add_child(achievements_container)
+        achievements_container.anchor_left = 0
+        achievements_container.anchor_top = 0
+        achievements_container.position = Vector2(870, 230)
 
-	for ach in ACHIEVEMENTS:
-		var btn := Button.new()
-		btn.text = ach["label"]
-		btn.disabled = true
-		achievements_container.add_child(btn)
-		achievement_buttons.append(btn)
+        # Label above the achievements
+        var ach_label := Label.new()
+        ach_label.text = "Achievements"
+        achievements_container.add_child(ach_label)
 
-		# Make the name input wider for easier typing
-		line_edit.custom_minimum_size = Vector2(250, 0)
+        for ach in ACHIEVEMENTS:
+                var btn := Button.new()
+                btn.text = ach["label"]
+                btn.disabled = true
+                btn.toggle_mode = true
+                achievements_container.add_child(btn)
+                achievement_buttons.append(btn)
+
+        # Make the name input wider for easier typing
+        line_edit.custom_minimum_size = Vector2(250, 0)
 
 func show_gameover(distance: float, wagons: int):
 	current_distance = distance
@@ -87,8 +93,9 @@ func _update_achievements():
 			unlocked = Hra.banana_total >= ach.value
 			unlocked = unlocked or (i < Hra.achievements_completed.size() and Hra.achievements_completed[i])
 
-		var btn: Button = achievement_buttons[i]
-		btn.text = ("\u2713 " + ach.label) if unlocked else ach.label
+               var btn: Button = achievement_buttons[i]
+               btn.text = ach.label
+               btn.button_pressed = unlocked
 
 func _on_restart_pressed():
 	transition_anim.play("blesk")

--- a/main.tscn
+++ b/main.tscn
@@ -250,6 +250,8 @@ volume_db = -7.172
 [node name="JumpSound" type="AudioStreamPlayer" parent="Player"]
 stream = ExtResource("24_4k2k6")
 
+[node name="BananaSound" type="AudioStreamPlayer" parent="Player"]
+
 [node name="Train" type="Node2D" parent="."]
 script = ExtResource("20_getpj")
 wagon_scene = ExtResource("21_getpj")
@@ -381,6 +383,8 @@ offset_right = 790.0
 offset_bottom = 360.0
 disabled = true
 text = "ACHIEVEMENT"
+
+[node name="AchievementSound" type="AudioStreamPlayer" parent="UI"]
 
 [node name="MobileUI" type="CanvasLayer" parent="."]
 

--- a/player.gd
+++ b/player.gd
@@ -25,6 +25,7 @@ const DEATH_Y_THRESHOLD = 900.0  # kdy hráč spadne pod mapu
 
 @onready var charge_sound: AudioStreamPlayer = $ChargeSound
 @onready var jump_sound: AudioStreamPlayer = $JumpSound
+@onready var banana_collect_sound: AudioStreamPlayer = $BananaSound
 
 
 
@@ -122,13 +123,15 @@ func start_parallax_transition(from_speed: float, to_speed: float):
 	parallax_active = true
 
 func die():
-	is_dead = true
-	gameover_node.show_gameover(distance_traveled, wagons_skipped)
+        is_dead = true
+        gameover_node.show_gameover(distance_traveled, wagons_skipped)
 
 func register_wagon(id: int):
-		if id != last_wagon_id:
-				wagons_skipped += 1
-				last_wagon_id = id
+        if id != last_wagon_id:
+                wagons_skipped += 1
+                last_wagon_id = id
 
 func collect_banana(amount: int = 1):
-		ui_node.add_banana(amount)
+        ui_node.add_banana(amount)
+        if banana_collect_sound:
+                banana_collect_sound.play()

--- a/ui.gd
+++ b/ui.gd
@@ -20,6 +20,7 @@ var unlocked := []
 @onready var score_label: Label = $ScoreLabel
 @onready var banana_label: Label = $BananaLabel
 @onready var achievement_popup: Button = $AchievementPopup
+@onready var achievement_sound: AudioStreamPlayer = $AchievementSound
 
 func _ready():
 	bananas = Hra.banana_total
@@ -66,10 +67,12 @@ func _check_achievements():
 			Hra.mark_achievement(i)
 
 func _show_achievement(text: String):
-	achievement_popup.text = text
-	achievement_popup.show()
-	achievement_popup.modulate.a = 0.0
-	var tw = create_tween()
+        achievement_popup.text = text
+        achievement_popup.show()
+        if achievement_sound:
+                achievement_sound.play()
+        achievement_popup.modulate.a = 0.0
+        var tw = create_tween()
 	tw.tween_property(achievement_popup, "modulate:a", 1.0, 0.4)
 	tw.tween_interval(1.2)
 	tw.tween_property(achievement_popup, "modulate:a", 0.0, 0.4)


### PR DESCRIPTION
## Summary
- show an "Achievements" label above earned achievements
- indicate completed achievements using pressed toggle buttons
- add optional sounds for banana collection and achievement unlocks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b210e6b088322a0c3d3ada11bc0a1